### PR TITLE
Feature/update about.html and common.css（btnクラスの追加）

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,7 +18,7 @@
             <h3 class="about">このおみくじについて</h3>
 
             <ul class="about">
-                <li>このおみくじは、コンピュータ・サイエンスの学習プラットフォーム <a href="https://recursionist.io/" target="_blank" rel="noopener noreferer">Recursion</a> で開催されているイベント「チーム開発体験会」の課題として制作されたものです。</li>
+                <li>このおみくじは、コンピュータ・サイエンスの学習プラットフォーム <a href="https://recursionist.io/" target="_blank" rel="noopener noreferrer">Recursion</a> で開催されているイベント「チーム開発体験会」の課題として制作されたものです。</li>
                 <li>あなたのソフトウェア開発の行方を占います。</li>
                 <li>「チーム開発体験会」が催される度におみくじの種類が増えてゆきますので、納得しかねるおみくじを引いてしまっても懲りずにまた引きに来るのが吉です。</li>
             </ul>

--- a/about.html
+++ b/about.html
@@ -13,6 +13,27 @@
 </head>
 
 <body>
+    <div class="page-container">
+        <section class="omikuji-frame">
+            <h3 class="about">このおみくじについて</h3>
+
+            <ul class="about">
+                <li>このおみくじは、コンピュータ・サイエンスの学習プラットフォーム <a href="https://recursionist.io/" target="_blank" rel="noopener noreferer">Recursion</a> で開催されているイベント「チーム開発体験会」の課題として制作されたものです。</li>
+                <li>あなたのソフトウェア開発の行方を占います。</li>
+                <li>「チーム開発体験会」が催される度におみくじの種類が増えてゆきますので、納得しかねるおみくじを引いてしまっても懲りずにまた引きに来るのが吉です。</li>
+            </ul>
+
+            
+        </section>
+        <a href="index.html" class="back-btn">戻る</a>
+
+        <footer class="about">
+            <p>©ソフトウェア開発みくじ</p>
+        
+        </footer>
+
+    </div>
+    
     
 
     <script src="js/main.js"></script>

--- a/about.html
+++ b/about.html
@@ -25,7 +25,7 @@
 
             
         </section>
-        <a href="index.html" class="back-btn">戻る</a>
+        <a href="index.html" class="btn">戻る</a>
 
         <footer class="about">
             <p>©ソフトウェア開発みくじ</p>

--- a/styles/common.css
+++ b/styles/common.css
@@ -11,7 +11,25 @@ body{
     justify-content: center;
     align-items: center;
     min-height: 100vh;
+    flex-direction: column; /*おみくじとボタンを縦並びにするため*/
+    gap: 20px; /*戻るボタンとomikuji-frameの間隔確保*/
+
 }
+
+.back-btn{ /*戻るボタンや、もう一度おみくじを引くボタンなどに使ってください*/
+    display: inline-block;
+    text-decoration: none;
+
+    background-color: #dc3545;
+    color: white;
+    padding: 7px 15px;
+    border-radius: 20px;
+    transition: 0.3s;
+}
+.back-btn:hover{
+    background-color: #c0392b;
+}
+
 
 .hidden{
     display: none !important; /*hiddenクラスを入れると表示されなくなる、表示したいときはhiddenクラスを消す*/
@@ -31,4 +49,36 @@ body{
 
     background-color: white;
     box-sizing: border-box;
+    padding: 16px;
 }
+
+/*about.htmlのクラス*/
+h3.about{
+    margin: 0;
+    padding-bottom: 16px;
+}
+ul.about{
+    text-align: left;
+    padding-left: 20px;
+    margin: 0;
+    list-style-type: square;
+
+}
+ul.about li{
+    line-height: 1.7em;
+    margin-bottom: 8px;
+}
+ul.about a{
+    text-decoration: none;
+}
+
+ul.about a:hover{
+    text-decoration: none;
+}
+
+
+footer.about p{
+    font-size: 8px;
+    font-family: Arial, Helvetica, sans-serif;
+}
+

--- a/styles/common.css
+++ b/styles/common.css
@@ -16,7 +16,7 @@ body{
 
 }
 
-.back-btn{ /*戻るボタンや、もう一度おみくじを引くボタンなどに使ってください*/
+.btn{ /*ボタンレイアウトです。戻るボタンや、もう一度おみくじを引くボタンなどに使ってください*/
     display: inline-block;
     text-decoration: none;
 
@@ -26,7 +26,7 @@ body{
     border-radius: 20px;
     transition: 0.3s;
 }
-.back-btn:hover{
+.btn:hover{
     background-color: #c0392b;
 }
 


### PR DESCRIPTION
## 概要

共通ボタンスタイルとして `.btn` クラスを導入しました。
**戻るボタンや「おみくじを引く」ボタンなど、ボタン系UIは `.btn` を使ってもらって大丈夫です。**

あわせて、aboutページを新規作成し、おみくじの説明内容を追加しました。
また、共通スタイル（common.css）を整理し、UIの調整を行いました。


https://github.com/user-attachments/assets/ff0398a1-288c-4d95-9bc1-b5cb2dd91f8c


https://github.com/user-attachments/assets/72979a46-ea5f-47cb-a8eb-b5f8c6311be9




---

## 変更内容

### 1. aboutページの追加

* `about.html` を新規作成
* おみくじの説明文を記載
* 外部リンク（Recursion）を別タブで開くように設定

  * `target="_blank"`
  * `rel="noopener noreferrer"`

---

### 2. レイアウト調整

* `.page-container` をflexレイアウトに設定
* `flex-direction: column` を指定し、要素を縦並びに変更
* `gap` を追加して要素間の余白を調整

---

### 3. 共通ボタンスタイルの導入（重要）

* `.btn` クラスを新規追加

  * ボタンの見た目を共通化
  * 戻るボタンや今後のボタンにも使い回し可能な設計
* hover時のスタイルも実装

---

### 4. スタイル調整（common.css）

* `h3.about`

  * デフォルトの余白を削除
* `ul.about`

  * 左寄せに変更
  * 余白・リストスタイル（square）を調整
* `ul.about li`

  * 行間・余白を調整
* `ul.about a`

  * 下線を削除

---

### 5. その他

* フッターのフォントサイズ・フォントを調整

---

## 確認内容

* aboutページが正しく表示されること
* 戻るボタンで `index.html` に遷移できること
* レイアウトが中央寄せ・縦並びになっていること
* 外部リンクが別タブで開くこと

---

## 補足

ページ遷移にはaタグを使用し、CSSでボタン風にスタイリングしています。
また、`.btn` クラスは共通ボタンとして他ページでも利用できるようにしています。

close #3 
