### PR TITLE
トップページ：おみくじ画像サイズとボタン・リンクの中央揃え調整

### DIFF
--- a/styles/top-style.css
+++ b/styles/top-style.css
@@ -1,0 +1,7 @@
+/* おみくじ画像を小さくする */
+.omikuji-image {
+    width: 200px; 
+    height: auto;
+    display: block;
+    margin: 0 auto; /* 中央寄せ */
+}

--- a/styles/top-style.css
+++ b/styles/top-style.css
@@ -6,4 +6,18 @@
     margin: 0 auto; /* 中央寄せ */
 }
 
+/* ボタンとリンクを縦に中央揃え */
+.button-area, .link-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px; /* 各要素の間隔 */
+}
 
+/* リンクのテキストを赤で下線に */
+.link-text {
+    color: #dc3545;
+    text-decoration: underline;
+    cursor: pointer;
+    margin: 0;
+}

--- a/styles/top-style.css
+++ b/styles/top-style.css
@@ -21,3 +21,26 @@
     cursor: pointer;
     margin: 0;
 }
+
+/* タイトルと画像の間に余白 */
+h1 {
+    margin-bottom: 30px;
+}
+
+/* おみくじ画像の上下に余白 */
+.omikuji-image {
+    width: 200px;
+    height: auto;
+    display: block;
+    margin: 30px auto; /* ← 上下に余白追加 */
+}
+
+/* ボタンの上に余白 */
+.button-area {
+    margin-top: 20px;
+}
+
+/* リンクエリアの上に余白 */
+.link-area {
+    margin-top: 15px;
+}

--- a/styles/top-style.css
+++ b/styles/top-style.css
@@ -5,3 +5,5 @@
     display: block;
     margin: 0 auto; /* 中央寄せ */
 }
+
+


### PR DESCRIPTION
概要
トップページのおみくじ画像と「おみくじを引く」ボタン、下のリンクの見た目を調整しました。

修正内容
1. おみくじ画像を小さくして中央寄せに
2. ボタンとリンクを、中央揃えに
3. リンクテキストを赤で下線を追加

対象ファイル
- styles/top-style.css

補足
- 画像サイズは幅200pxに設定していますが、必要に応じて調整可能です。
